### PR TITLE
protobuf-c: add ld flag

### DIFF
--- a/packages/dev-libs/protobuf-c/protobuf-c-1.3.2-r1.exheres-0
+++ b/packages/dev-libs/protobuf-c/protobuf-c-1.3.2-r1.exheres-0
@@ -22,3 +22,6 @@ DEPENDENCIES="
 
 BUGS_TO="will@worrbase.com"
 
+src_configure() {
+    LDFLAGS="${LDFLAGS} -Wl,--no-as-needed" econf
+}


### PR DESCRIPTION
This is a workaround as shown in the link to the error below.

https://github.com/protocolbuffers/protobuf/issues/4958#issuecomment-510760038

Error message:
```
...
/usr/x86_64-pc-linux-gnu/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I. --c_out=. ./t/test.proto
/usr/x86_64-pc-linux-gnu/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I. --c_out=. ./t/test.proto
/usr/x86_64-pc-linux-gnu/bin/protoc --plugin=protoc-gen-c=./protoc-c/protoc-gen-c -I. --c_out=. ./t/test-full.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/test.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
[libprotobuf WARNING google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/test.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
[libprotobuf WARNING google/protobuf/compiler/parser.cc:564] No syntax specified for the proto file: t/test-full.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
--c_out: protoc-gen-c: Plugin killed by signal 6.
make: *** [Makefile:2395: t/test.pb-c.c] Error 1
make: *** Waiting for unfinished jobs....
--c_out: protoc-gen-c: Plugin killed by signal 6.
make: *** [Makefile:2395: t/test.pb-c.h] Error 1
--c_out: protoc-gen-c: Plugin killed by signal 6.
make: *** [Makefile:2401: t/test-full.pb-c.c] Error 1

Error:
  * In program cave --colour yes perform install --hooks --managed-output --output-exclusivity with-others =dev-libs/protobuf-c-1.3.2-r1:0::worr --destination installed --replacing =dev-libs/protobuf-c-1.3.2:0::installed --x-of-y 1 of 1:
  * When installing 'dev-libs/protobuf-c-1.3.2-r1:0::worr' replacing { 'dev-libs/protobuf-c-1.3.2:0::installed' }:
  * When running an ebuild command on 'dev-libs/protobuf-c-1.3.2-r1:0::worr':
  * Install failed for 'dev-libs/protobuf-c-1.3.2-r1:0::worr' (paludis::ActionFailedError)


!!! ERROR in dev-libs/protobuf-c-1.3.2-r1::worr:
!!! In /usr/x86_64-pc-linux-gnu/libexec/paludis/utils/exheres-0/emake at line 30
!!! emake returned error 2

!!! Call stack:
!!!    * paludis_die_or_error_func (/usr/x86_64-pc-linux-gnu/libexec/paludis/die_functions.bash:82)
!!!    * main (/usr/x86_64-pc-linux-gnu/libexec/paludis/utils/exheres-0/emake:30)

diefunc: making ebuild PID 381047 exit with error
die trap: exiting with error.

Failed install to / for dev-libs/protobuf-c-1.3.2-r1:0::worr replacing 1.3.2:0::installed
```